### PR TITLE
add glfw version 3 support for AntTweakBar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ ADD_DEFINITIONS(-D_UNIX)
 add_library(AntTweakBar ${SOURCES})
 target_link_libraries(AntTweakBar GL)
 
+set(AntTweakTools_BUILD_EXAMPLES TRUE)
 if (AntTweakTools_BUILD_EXAMPLES)
     add_subdirectory(examples) 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ ADD_DEFINITIONS(-D_UNIX)
 add_library(AntTweakBar ${SOURCES})
 target_link_libraries(AntTweakBar GL)
 
-set(AntTweakTools_BUILD_EXAMPLES TRUE)
-if (AntTweakTools_BUILD_EXAMPLES)
+Option(AntTweakBar_BUILD_EXAMPLES "Build the AntTweakBarexample programs" ON)
+if (AntTweakBar_BUILD_EXAMPLES)
     add_subdirectory(examples) 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,18 +15,7 @@ ADD_DEFINITIONS(-D_UNIX)
 add_library(AntTweakBar ${SOURCES})
 target_link_libraries(AntTweakBar GL)
 
-add_executable(TwAdvanced1 examples/TwAdvanced1.cpp)
-target_link_libraries(TwAdvanced1 AntTweakBar GLU glfw)
-
-add_executable(TwSimpleGLFW examples/TwSimpleGLFW.cpp)
-target_link_libraries(TwSimpleGLFW AntTweakBar GLU glfw)
-
-add_executable(TwSimpleGLUT examples/TwSimpleGLUT.cpp)
-target_link_libraries(TwSimpleGLUT AntTweakBar GLU glut)
-
-add_executable(TwSimpleSDL examples/TwSimpleSDL.cpp)
-target_link_libraries(TwSimpleSDL AntTweakBar GLU SDL)
-
-add_executable(TwString examples/TwString.cpp)
-target_link_libraries(TwString AntTweakBar glfw)
+if (AntTweakTools_BUILD_EXAMPLES)
+    add_subdirectory(examples) 
+endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,15 +1,21 @@
+
+set(LIBS AntTweakBar)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux") 
+    LIST (APPEND LIBS X11) 
+endif()
+
 add_executable(TwAdvanced1 TwAdvanced1.cpp)
-target_link_libraries(TwAdvanced1 AntTweakBar GLU glfw)
+target_link_libraries(TwAdvanced1 ${LIBS} GLU glfw)
 
 add_executable(TwSimpleGLFW TwSimpleGLFW.cpp)
-target_link_libraries(TwSimpleGLFW AntTweakBar GLU glfw)
+target_link_libraries(TwSimpleGLFW ${LIBS} GLU glfw)
 
 add_executable(TwSimpleGLUT TwSimpleGLUT.cpp)
-target_link_libraries(TwSimpleGLUT AntTweakBar GLU glut)
+target_link_libraries(TwSimpleGLUT ${LIBS} GLU glut)
 
 add_executable(TwSimpleSDL TwSimpleSDL.cpp)
-target_link_libraries(TwSimpleSDL AntTweakBar GLU SDL)
+target_link_libraries(TwSimpleSDL ${LIBS} GLU SDL)
 
 add_executable(TwString TwString.cpp)
-target_link_libraries(TwString AntTweakBar glfw)
+target_link_libraries(TwString ${LIBS} glfw)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(TwAdvanced1 TwAdvanced1.cpp)
+target_link_libraries(TwAdvanced1 AntTweakBar GLU glfw)
+
+add_executable(TwSimpleGLFW TwSimpleGLFW.cpp)
+target_link_libraries(TwSimpleGLFW AntTweakBar GLU glfw)
+
+add_executable(TwSimpleGLUT TwSimpleGLUT.cpp)
+target_link_libraries(TwSimpleGLUT AntTweakBar GLU glut)
+
+add_executable(TwSimpleSDL TwSimpleSDL.cpp)
+target_link_libraries(TwSimpleSDL AntTweakBar GLU SDL)
+
+add_executable(TwString TwString.cpp)
+target_link_libraries(TwString AntTweakBar glfw)
+

--- a/src/TwEventGLFW.cpp
+++ b/src/TwEventGLFW.cpp
@@ -14,8 +14,16 @@
 //
 //  ---------------------------------------------------------------------------
 
-#include <GL/glew.h>
+#ifndef GLFW_VERSION_MAJOR 
+#define GLFW_VERSION_MAJOR  2
+#endif
+
+#if GLFW_VERSION_MAJOR == 2
+#include <GL/glfw.h>
+#elif GLFW_VERSION_MAJOR == 3
 #include <GLFW/glfw3.h>
+#endif 
+
 // note: AntTweakBar.dll does not need to link with GLFW, 
 // it just needs some definitions for its helper functions.
 
@@ -45,12 +53,56 @@ int TW_CALL TwEventKeyGLFW(int glfwKey, int glfwAction)
 {
     int handled = 0;
 
+#if GLFW_VERSION_MAJOR == 2
+    // Register of modifiers state
+    if( glfwAction==GLFW_PRESS )
+    {
+        switch( glfwKey )
+        {
+        case GLFW_KEY_LSHIFT:
+        case GLFW_KEY_RSHIFT:
+            g_KMod |= TW_KMOD_SHIFT;
+            break;
+        case GLFW_KEY_LCTRL:
+        case GLFW_KEY_RCTRL:
+            g_KMod |= TW_KMOD_CTRL;
+            break;
+        case GLFW_KEY_LALT:
+        case GLFW_KEY_RALT:
+            g_KMod |= TW_KMOD_ALT;
+            break;
+        }
+    }
+    else
+    {
+        switch( glfwKey )
+        {
+        case GLFW_KEY_LSHIFT:
+        case GLFW_KEY_RSHIFT:
+            g_KMod &= ~TW_KMOD_SHIFT;
+            break;
+        case GLFW_KEY_LCTRL:
+        case GLFW_KEY_RCTRL:
+            g_KMod &= ~TW_KMOD_CTRL;
+            break;
+        case GLFW_KEY_LALT:
+        case GLFW_KEY_RALT:
+            g_KMod &= ~TW_KMOD_ALT;
+            break;
+        }
+    }
     // Process key pressed
     if( glfwAction==GLFW_PRESS )
     {
         int mod = g_KMod;
         int testkp = ((mod&TW_KMOD_CTRL) || (mod&TW_KMOD_ALT)) ? 1 : 0;
 
+#if GLFW_VERSION_MAJOR == 2
+        if( (mod&TW_KMOD_CTRL) && glfwKey>0 && glfwKey<GLFW_KEY_SPECIAL )   // CTRL cases
+            handled = TwKeyPressed(glfwKey, mod);
+        else if( glfwKey>=GLFW_KEY_SPECIAL )
+        {
+#endif
             int k = 0;
 
             if( glfwKey>=GLFW_KEY_F1 && glfwKey<=GLFW_KEY_F15 )
@@ -61,6 +113,20 @@ int TW_CALL TwEventKeyGLFW(int glfwKey, int glfwAction)
             {
                 switch( glfwKey )
                 {
+#if GLFW_VERSION_MAJOR == 2
+                case GLFW_KEY_ESC:
+                    k = TW_KEY_ESCAPE;
+                    break;
+                case GLFW_KEY_DEL:
+                    k = TW_KEY_DELETE;
+                    break;
+                case GLFW_KEY_PAGEUP:
+                    k = TW_KEY_PAGE_UP;
+                    break;
+                case GLFW_KEY_PAGEDOWN:
+                    k = TW_KEY_PAGE_DOWN;
+                    break;
+#endif 
                 case GLFW_KEY_UP:
                     k = TW_KEY_UP;
                     break;
@@ -123,7 +189,10 @@ int TW_CALL TwEventKeyGLFW(int glfwKey, int glfwAction)
 
             if( k>0 )
                 handled = TwKeyPressed(k, mod);
-        
+
+#if GLFW_VERSION_MAJOR == 2 
+        }
+#endif 
     }
 
     return handled;

--- a/src/TwEventGLFW.cpp
+++ b/src/TwEventGLFW.cpp
@@ -14,7 +14,8 @@
 //
 //  ---------------------------------------------------------------------------
 
-#include <GL/glfw.h>
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
 // note: AntTweakBar.dll does not need to link with GLFW, 
 // it just needs some definitions for its helper functions.
 
@@ -44,54 +45,12 @@ int TW_CALL TwEventKeyGLFW(int glfwKey, int glfwAction)
 {
     int handled = 0;
 
-    // Register of modifiers state
-    if( glfwAction==GLFW_PRESS )
-    {
-        switch( glfwKey )
-        {
-        case GLFW_KEY_LSHIFT:
-        case GLFW_KEY_RSHIFT:
-            g_KMod |= TW_KMOD_SHIFT;
-            break;
-        case GLFW_KEY_LCTRL:
-        case GLFW_KEY_RCTRL:
-            g_KMod |= TW_KMOD_CTRL;
-            break;
-        case GLFW_KEY_LALT:
-        case GLFW_KEY_RALT:
-            g_KMod |= TW_KMOD_ALT;
-            break;
-        }
-    }
-    else
-    {
-        switch( glfwKey )
-        {
-        case GLFW_KEY_LSHIFT:
-        case GLFW_KEY_RSHIFT:
-            g_KMod &= ~TW_KMOD_SHIFT;
-            break;
-        case GLFW_KEY_LCTRL:
-        case GLFW_KEY_RCTRL:
-            g_KMod &= ~TW_KMOD_CTRL;
-            break;
-        case GLFW_KEY_LALT:
-        case GLFW_KEY_RALT:
-            g_KMod &= ~TW_KMOD_ALT;
-            break;
-        }
-    }
-
     // Process key pressed
     if( glfwAction==GLFW_PRESS )
     {
         int mod = g_KMod;
         int testkp = ((mod&TW_KMOD_CTRL) || (mod&TW_KMOD_ALT)) ? 1 : 0;
 
-        if( (mod&TW_KMOD_CTRL) && glfwKey>0 && glfwKey<GLFW_KEY_SPECIAL )   // CTRL cases
-            handled = TwKeyPressed(glfwKey, mod);
-        else if( glfwKey>=GLFW_KEY_SPECIAL )
-        {
             int k = 0;
 
             if( glfwKey>=GLFW_KEY_F1 && glfwKey<=GLFW_KEY_F15 )
@@ -102,9 +61,6 @@ int TW_CALL TwEventKeyGLFW(int glfwKey, int glfwAction)
             {
                 switch( glfwKey )
                 {
-                case GLFW_KEY_ESC:
-                    k = TW_KEY_ESCAPE;
-                    break;
                 case GLFW_KEY_UP:
                     k = TW_KEY_UP;
                     break;
@@ -128,15 +84,6 @@ int TW_CALL TwEventKeyGLFW(int glfwKey, int glfwAction)
                     break;
                 case GLFW_KEY_INSERT:
                     k = TW_KEY_INSERT;
-                    break;
-                case GLFW_KEY_DEL:
-                    k = TW_KEY_DELETE;
-                    break;
-                case GLFW_KEY_PAGEUP:
-                    k = TW_KEY_PAGE_UP;
-                    break;
-                case GLFW_KEY_PAGEDOWN:
-                    k = TW_KEY_PAGE_DOWN;
                     break;
                 case GLFW_KEY_HOME:
                     k = TW_KEY_HOME;
@@ -176,7 +123,7 @@ int TW_CALL TwEventKeyGLFW(int glfwKey, int glfwAction)
 
             if( k>0 )
                 handled = TwKeyPressed(k, mod);
-        }
+        
     }
 
     return handled;

--- a/src/TwEventGLFW.cpp
+++ b/src/TwEventGLFW.cpp
@@ -91,6 +91,7 @@ int TW_CALL TwEventKeyGLFW(int glfwKey, int glfwAction)
             break;
         }
     }
+#endif
     // Process key pressed
     if( glfwAction==GLFW_PRESS )
     {


### PR DESCRIPTION
AntTweakBar works now with glfw 3
the examples based on glfw2 are not yet changed to use glfw3 
